### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,13 +12,13 @@ HP03S	KEYWORD1
 # Methods and Functions (KEYWORD2)
 ###########################################
 
-begin KEYWORD2
-printParameters KEYWORD2
-printAllValues KEYWORD2
-measure KEYWORD2
-measureTemperature KEYWORD2
-measurePressure KEYWORD2
-getTemperature KEYWORD2
-getPressure KEYWORD2
-getPressureAtSeaLevel KEYWORD2
+begin	KEYWORD2
+printParameters	KEYWORD2
+printAllValues	KEYWORD2
+measure	KEYWORD2
+measureTemperature	KEYWORD2
+measurePressure	KEYWORD2
+getTemperature	KEYWORD2
+getPressure	KEYWORD2
+getPressureAtSeaLevel	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords